### PR TITLE
Fix code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/user_api.py
+++ b/user_api.py
@@ -8,7 +8,10 @@ import time
 import sqlite3
 from network_info_wizard import NetworkInformation
 from network_connection_analyzer import NetworkManager
+import logging
 
+# Configure logging
+logging.basicConfig(level=logging.ERROR, format='%(asctime)s %(levelname)s %(message)s')
 
 class Database:
     """Class responsible for interacting with the SQLite database for request limits."""
@@ -139,8 +142,9 @@ class App:
             return jsonify(statistics), 200
 
         except Exception as e:
-            # Log the error (not shown here, but would be logged in a real application)
-            return jsonify({'error': f'Internal server error: {str(e)}'}), 500
+            # Log the error
+            logging.error(f"Error in get_report: {e}")
+            return jsonify({'error': 'Internal server error. Please try again later.'}), 500
 
     def run(self):
         """Run the Flask app."""


### PR DESCRIPTION
Fixes [https://github.com/kavineksith/Network-Analyzing-Wizard-API/security/code-scanning/1](https://github.com/kavineksith/Network-Analyzing-Wizard-API/security/code-scanning/1)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling in the `get_report` method to log the exception and return a generic error message.

1. Import the `logging` module to enable logging of exceptions.
2. Configure the logging settings to log error messages.
3. Modify the exception handling in the `get_report` method to log the detailed exception message and return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
